### PR TITLE
Fix VitePress build — increase Node.js memory to 8GB

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build with VitePress
-        run: npm run docs:build
+        run: NODE_OPTIONS="--max-old-space-size=8192" npm run docs:build
+        env:
+          NODE_OPTIONS: "--max-old-space-size=8192"
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary

The VitePress build was failing with 'JavaScript heap out of memory' error (3.5GB+). This PR increases the Node.js memory limit to 8GB.

## Changes
- Added NODE_OPTIONS="--max-old-space-size=8192" to the build step
- This allows VitePress to use up to 8GB of memory during the build

## Result
VitePress should now build successfully and docs.opensin.ai will be deployed.