### PR TITLE
docs: add agent roadmap to repo guides

### DIFF
--- a/docs/guide/opensin-ai-cli.md
+++ b/docs/guide/opensin-ai-cli.md
@@ -6,6 +6,12 @@ OpenSIN-AI CLI ist der hochperformante, speicher-sichere AI Coding Assistant der
 >
 > **Umfang:** 70 Dateien | 34.601 Zeilen Rust-Code | 9 Crates
 
+## OpenSIN-AI Agent Roadmap
+
+- Feature spec: [OpenSIN-overview/docs/opensin-ai-agent-feature-spec.md](https://github.com/OpenSIN-AI/OpenSIN-overview/blob/main/docs/opensin-ai-agent-feature-spec.md)
+- Comparison guide: [OpenSIN-AI Agent Features](opensin-ai-agent-features.md)
+- Verified runtime: heartbeat, cron, failover, approval hooks, and orchestrator-aware CLI routing
+
 ---
 
 ## Architektur

--- a/docs/guide/opensin-ai-code.md
+++ b/docs/guide/opensin-ai-code.md
@@ -6,6 +6,12 @@ OpenSIN-AI Code ist die Python-basierte Agent Development Platform der OpenSIN-A
 >
 > **Umfang:** 100 Dateien | 2.386 Zeilen Python-Code | 26 Subsystem-Pakete
 
+## OpenSIN-AI Agent Roadmap
+
+- Feature spec: [OpenSIN-overview/docs/opensin-ai-agent-feature-spec.md](https://github.com/OpenSIN-AI/OpenSIN-overview/blob/main/docs/opensin-ai-agent-feature-spec.md)
+- Comparison guide: [OpenSIN-AI Agent Features](opensin-ai-agent-features.md)
+- This repo maps the Python agent development surface to the same OpenSIN-AI Agent roadmap.
+
 ---
 
 ## Architektur

--- a/docs/guide/opensin-ai-overview.md
+++ b/docs/guide/opensin-ai-overview.md
@@ -4,6 +4,12 @@ OpenSIN-AI ist das umfassendste AI Agent System der Welt. Eine vollständige Pla
 
 > **175 Repositories | 17 Teams | 92 Worker | 7 MCP Server | 19 Plugins/Skills | 6 Domains**
 
+## OpenSIN-AI Agent Roadmap
+
+- Feature spec: [OpenSIN-overview/docs/opensin-ai-agent-feature-spec.md](https://github.com/OpenSIN-AI/OpenSIN-overview/blob/main/docs/opensin-ai-agent-feature-spec.md)
+- Comparison guide: [OpenSIN-AI Agent Features](opensin-ai-agent-features.md)
+- Verified runtime layer now spans heartbeat, cron, failover, approval hooks, and a unified orchestrator.
+
 ---
 
 ## 🚀 Die OpenSIN-AI Familie

--- a/docs/guide/opensin-ai-platform.md
+++ b/docs/guide/opensin-ai-platform.md
@@ -6,6 +6,12 @@ OpenSIN-AI Platform ist das Plugin- und Automatisierungs-Ökosystem der OpenSIN-
 >
 > **Umfang:** 182 Dateien | 87.247 Zeilen | 14 Plugins
 
+## OpenSIN-AI Agent Roadmap
+
+- Feature spec: [OpenSIN-overview/docs/opensin-ai-agent-feature-spec.md](https://github.com/OpenSIN-AI/OpenSIN-overview/blob/main/docs/opensin-ai-agent-feature-spec.md)
+- Comparison guide: [OpenSIN-AI Agent Features](opensin-ai-agent-features.md)
+- This repo documents the automation and plugin surfaces that support the OpenSIN-AI Agent stack.
+
 ---
 
 ## Plugin Ecosystem


### PR DESCRIPTION
## Summary
- Add OpenSIN-AI Agent roadmap references to the repo-specific guide pages.
- Surface the feature spec and comparison guide alongside the existing repo docs.