### PR TITLE
docs: link-fix sweep for 4 archived repos (consolidation April 2026)

### DIFF
--- a/docs/guide/onboarding.md
+++ b/docs/guide/onboarding.md
@@ -14,8 +14,8 @@ When a new user runs OpenSIN for the first time, the autonomous onboarding syste
 ## Quick Start
 
 ```bash
-git clone https://github.com/OpenSIN-AI/OpenSIN-onboarding.git
-cd OpenSIN-onboarding
+git clone https://github.com/OpenSIN-AI/Infra-SIN-Dev-Setup.git
+cd Infra-SIN-Dev-Setup/user-onboarding
 ./scripts/onboard.sh
 ```
 
@@ -115,7 +115,7 @@ rm /tmp/new-key.json
 
 ## Further Reading
 
-- [OpenSIN-onboarding repository](https://github.com/OpenSIN-AI/OpenSIN-onboarding)
+- [Infra-SIN-Dev-Setup / user-onboarding](https://github.com/OpenSIN-AI/Infra-SIN-Dev-Setup/tree/main/user-onboarding) (previously `OpenSIN-onboarding`, consolidated April 2026)
 - [Passwordmanager source](https://github.com/OpenSIN-AI/OpenSIN-backend/tree/main/a2a/team-infrastructure/A2A-SIN-Passwordmanager)
 - [OpenSIN Bridge extension](https://github.com/OpenSIN-AI/OpenSIN-backend/tree/main/services/sin-chrome-extension)
 

--- a/docs/guide/opensin-ai-code.md
+++ b/docs/guide/opensin-ai-code.md
@@ -1,177 +1,32 @@
 # OpenSIN-AI Code — Python Agent Development Platform
 
-OpenSIN-AI Code ist die Python-basierte Agent Development Platform der OpenSIN-AI Organisation. Metadata-driven Architektur für schnellen Prototyping und Porting.
-
-> **Repository:** [OpenSIN-AI/opensin-ai-code](https://github.com/OpenSIN-AI/opensin-ai-code)
+> **Update April 2026:** The standalone `OpenSIN-AI/opensin-ai-code` repository has been consolidated into the OpenSIN monorepo as `opensin_agent_platform/`.
 >
-> **Umfang:** 100 Dateien | 2.386 Zeilen Python-Code | 26 Subsystem-Pakete
+> **New location:** [`OpenSIN-AI/OpenSIN/opensin_agent_platform`](https://github.com/OpenSIN-AI/OpenSIN/tree/main/opensin_agent_platform)
 
-## OpenSIN-AI Agent Roadmap
+OpenSIN-AI Code is the Python-based Agent Development Platform. It was originally shipped as its own repo; as of the April 2026 consolidation it lives inside `OpenSIN` next to the other canonical Python packages (`opensin_core`, `opensin_cli`, `opensin_api`, `opensin_sdk`).
 
-- Feature spec: [OpenSIN-overview/docs/opensin-ai-agent-feature-spec.md](https://github.com/OpenSIN-AI/OpenSIN-overview/blob/main/docs/opensin-ai-agent-feature-spec.md)
-- Comparison guide: [OpenSIN-AI Agent Features](opensin-ai-agent-features.md)
-- This repo maps the Python agent development surface to the same OpenSIN-AI Agent roadmap.
+> **Status:** Preserved as reference material under `OpenSIN/opensin_agent_platform/`. Not yet wired into the `OpenSIN` build. The follow-up rationalization will port genuinely useful logic into `opensin_core` and retire the folder. See [`opensin_agent_platform/README.md`](https://github.com/OpenSIN-AI/OpenSIN/blob/main/opensin_agent_platform/README.md) for the plan.
 
----
+## Why consolidated
 
-## Architektur
+- The standalone repo advertised `pip install opensin-ai-code` but shipped no `pyproject.toml`, so the install path never worked.
+- It duplicated ground already covered by `opensin_core` in the `OpenSIN` repo (both define `hooks`, `plugins`, `skills`, QueryEngine, Tool/Permission/Memory systems).
 
-OpenSIN-AI Code ist als metadata-driven Python Workspace organisiert:
+Full rationale: [OpenSIN-overview consolidation report](https://github.com/OpenSIN-AI/OpenSIN-overview/blob/main/docs/CONSOLIDATION-2026-04.md).
 
-```
-opensin-ai-code/
-├── README.md               # Projektdokumentation
-├── LICENSE                 # Apache 2.0
-├── src/
-│   ├── main.py             # CLI Entry Point (argparse)
-│   ├── runtime.py          # PortRuntime: Routing, Bootstrap, Turn Loops
-│   ├── query_engine.py     # QueryEnginePort: Message Submission, Streaming
-│   ├── QueryEngine.py      # QueryEngineRuntime Wrapper
-│   ├── commands.py         # Command Surface (207 entries)
-│   ├── tools.py            # Tool Surface (184 entries)
-│   ├── session_store.py    # Session Persistence
-│   ├── transcript.py       # Transcript Buffer
-│   ├── port_manifest.py    # Workspace Manifest
-│   ├── parity_audit.py     # Python vs TypeScript Coverage
-│   ├── command_graph.py    # Command Segmentation
-│   ├── bootstrap_graph.py  # Bootstrap Stages
-│   ├── tool_pool.py        # Tool Pool Assembly
-│   ├── permissions.py      # Tool Permission Context
-│   ├── execution_registry.py  # Mirrored Command/Tool Wrappers
-│   ├── setup.py            # Setup Report
-│   ├── prefetch.py         # Simulated Prefetches
-│   ├── deferred_init.py    # Trust-gated Init
-│   ├── system_init.py      # System Init Message Builder
-│   ├── models.py           # Core Dataclasses
-│   ├── context.py          # Port Context
-│   ├── history.py          # Event Log
-│   ├── cost_tracker.py     # Cost Tracking
-│   ├── costHook.py         # Cost Hook Application
-│   ├── remote_runtime.py   # Remote Mode Simulation
-│   ├── direct_modes.py     # Direct-connect Modes
-│   ├── task.py             # Task Stub
-│   ├── tasks.py            # Default Tasks
-│   ├── Tool.py             # Tool Definitions
-│   ├── query.py            # Query DTOs
-│   ├── replLauncher.py     # REPL Banner
-│   ├── dialogLaunchers.py  # Dialog Launchers
-│   ├── ink.py              # Markdown Rendering
-│   ├── interactiveHelpers.py  # Utility Helpers
-│   ├── projectOnboardingState.py  # Onboarding State
-│   └── [26 subdirectories] # Placeholder packages loading JSON metadata
-└── tests/
-    └── test_porting_workspace.py
-```
-
----
-
-## Core Components
-
-### CLI Entry Point (`main.py`)
-
-Argparse-basierter Router mit 25+ Subcommands:
-- `summary` — Porting-Zusammenfassung
-- `manifest` — Workspace Manifest
-- `parity-audit` — Coverage-Vergleich
-- `route`, `bootstrap`, `turn-loop` — Runtime-Simulation
-- `remote-mode`, `ssh-mode` — Remote-Modi
-
-### QueryEngine (`query_engine.py`)
-
-`QueryEnginePort` Klasse:
-- Message Submission
-- Turn Loop Execution
-- Streaming Support
-- Session Persistence
-- Structured Output
-- Context Compacting
-
-### PortRuntime (`runtime.py`)
-
-`PortRuntime` Klasse:
-- Prompt Routing zu Commands/Tools
-- Session Bootstrap
-- Multi-Turn Loop Execution
-- Permission Denial Inference
-
-### Reference Data
-
-JSON Snapshots in `reference_data/`:
-- `archive_surface_snapshot.json` — 1902 TS-Dateien, 207 Commands, 184 Tools
-- `commands_snapshot.json` — 207 Command Entries
-- `tools_snapshot.json` — 184 Tool Entries
-- `subsystems/*.json` — 29 Subsystem Metadata Files
-
----
-
-## Subsystem Packages
-
-| Subsystem | Beschreibung |
-|-----------|-------------|
-| `assistant/` | Assistant Module |
-| `bootstrap/` | Bootstrap Module |
-| `bridge/` | Bridge Module |
-| `buddy/` | Buddy Companion |
-| `cli/` | CLI Module |
-| `components/` | UI Components |
-| `constants/` | Constants |
-| `coordinator/` | Task Coordinator |
-| `entrypoints/` | Entry Points |
-| `hooks/` | Hook System |
-| `keybindings/` | Keybindings |
-| `memdir/` | Memory Directory |
-| `migrations/` | Migrations |
-| `moreright/` | MoreRight Module |
-| `native_ts/` | Native TypeScript Bridge |
-| `outputStyles/` | Output Styles |
-| `plugins/` | Plugin System |
-| `remote/` | Remote Module |
-| `schemas/` | Data Schemas |
-| `screens/` | Screen Definitions |
-| `server/` | Server Module |
-| `services/` | Services |
-| `skills/` | Skills System |
-| `state/` | State Management |
-| `types/` | Type Definitions |
-| `upstreamproxy/` | Upstream Proxy |
-| `utils/` | Utilities |
-| `vim/` | Vim Integration |
-| `voice/` | Voice Module |
-
----
-
-## Schnellstart
+## Getting the source
 
 ```bash
-# Repository klonen
-git clone https://github.com/OpenSIN-AI/opensin-ai-code.git
-cd opensin-ai-code
-
-# Porting-Zusammenfassung
-python3 -m src.main summary
-
-# Workspace Manifest
-python3 -m src.main manifest
-
-# Subsysteme auflisten
-python3 -m src.main subsystems --limit 16
-
-# Tests ausführen
-python3 -m unittest discover -s tests -v
+git clone https://github.com/OpenSIN-AI/OpenSIN.git
+cd OpenSIN/opensin_agent_platform
 ```
 
----
+All 100 Python files and 26 subsystem packages are preserved exactly as they were in the standalone repo.
 
-*Zuletzt aktualisiert: 2026-04-07 | OpenSIN-AI*
+## See also
 
----
-
-## Relevante Mandate
-
-| Mandat | Priority | Doku |
-|--------|----------|------|
-| **Bun-Only** | -1.5 | `bun install` / `bun run` statt npm |
-| **Annahmen-Verbot** | -5.0 | KEINE Diagnose ohne Beweis |
-| **Test-Beweis-Pflicht** | 0.0 | KEIN "Done" ohne echten Test-Lauf |
-
-→ [Alle Mandate](/best-practices/code-quality)
+- [OpenSIN Repository](https://github.com/OpenSIN-AI/OpenSIN) — the canonical Python monorepo
+- [OpenSIN-AI Code Agent Comparison](opensin-ai-agent-features.md)
+- [OpenSIN-AI Agent Feature Spec](https://github.com/OpenSIN-AI/OpenSIN-overview/blob/main/docs/opensin-ai-agent-feature-spec.md)
+- [Canonical Repos Map](https://github.com/OpenSIN-AI/OpenSIN-overview/blob/main/docs/CANONICAL-REPOS.md)

--- a/docs/guide/opensin-ai-overview.md
+++ b/docs/guide/opensin-ai-overview.md
@@ -22,7 +22,7 @@ OpenSIN-AI ist das umfassendste AI Agent System der Welt. Eine vollständige Pla
 | **OpenSIN Backend** | [OpenSIN-AI/OpenSIN-backend](https://github.com/OpenSIN-AI/OpenSIN-backend) | Python + Node.js | 11.679 | SIN Solver | ✅ Abo-Modell |
 | **OpenSIN-Code** | [OpenSIN-AI/OpenSIN-Code](https://github.com/OpenSIN-AI/OpenSIN-Code) | TypeScript + Rust | 4.636 | 37.7K Rust | ✅ CLI |
 | **opensin-ai-cli** | [OpenSIN-AI/opensin-ai-cli](https://github.com/OpenSIN-AI/opensin-ai-cli) | Rust | 70 | 34.601 | ✅ NEU April 2026 |
-| **opensin-ai-code** | [OpenSIN-AI/opensin-ai-code](https://github.com/OpenSIN-AI/opensin-ai-code) | Python | 100 | 2.386 | ✅ NEU April 2026 |
+| **opensin-ai-code** *(archived)* | [OpenSIN-AI/OpenSIN/opensin_agent_platform](https://github.com/OpenSIN-AI/OpenSIN/tree/main/opensin_agent_platform) | Python | 100 | 2.386 | ⚠️ Consolidated 2026-04 into OpenSIN monorepo |
 | **opensin-ai-platform** | [OpenSIN-AI/opensin-ai-platform](https://github.com/OpenSIN-AI/opensin-ai-platform) | Multi | 182 | 87.247 | ✅ NEU April 2026 |
 
 ### Team Orchestrators (17 Teams, 92 Worker)

--- a/docs/guide/opensin-code.md
+++ b/docs/guide/opensin-code.md
@@ -191,7 +191,7 @@ Die gesamte Codebasis wurde von sin-claude nach OpenSIN-AI migriert:
 | Projekt | Repo | Dateien | Zeilen | Status |
 |---------|------|---------|--------|--------|
 | **OpenSIN-AI CLI** | [opensin-ai-cli](https://github.com/OpenSIN-AI/opensin-ai-cli) | 70 | 34.601 | ✅ Rust |
-| **OpenSIN-AI Code** | [opensin-ai-code](https://github.com/OpenSIN-AI/opensin-ai-code) | 100 | 2.386 | ✅ Python |
+| **OpenSIN-AI Code** | [OpenSIN/opensin_agent_platform](https://github.com/OpenSIN-AI/OpenSIN/tree/main/opensin_agent_platform) | 100 | 2.386 | ⚠️ Consolidated 2026-04 |
 | **OpenSIN-AI Platform** | [opensin-ai-platform](https://github.com/OpenSIN-AI/opensin-ai-platform) | 182 | 87.247 | ✅ Plugins |
 
 ---

--- a/docs/guide/passwordmanager.md
+++ b/docs/guide/passwordmanager.md
@@ -67,7 +67,7 @@ spm run-action '{"action":"sin.passwordmanager.secret.get","name":"MY_KEY","reve
 
 ## Setup
 
-See [Onboarding Guide](/guide/onboarding) for automated setup, or the [OpenSIN-onboarding repo](https://github.com/OpenSIN-AI/OpenSIN-onboarding) for manual installation.
+See [Onboarding Guide](/guide/onboarding) for automated setup, or the [Infra-SIN-Dev-Setup / user-onboarding](https://github.com/OpenSIN-AI/Infra-SIN-Dev-Setup/tree/main/user-onboarding) for manual installation.
 
 ## Source Code
 

--- a/docs/storage/box-cloud-storage.md
+++ b/docs/storage/box-cloud-storage.md
@@ -320,7 +320,7 @@ Beim OpenSIN Onboarding MUSS der User einen Storage Provider wählen:
 ## Related
 - [Infra-SIN-Dev-Setup](https://github.com/OpenSIN-AI/Infra-SIN-Dev-Setup/blob/main/box-storage.md) — Detailed Box Storage Guide
 - [Infra-SIN-Docker-Empire](https://github.com/OpenSIN-AI/Infra-SIN-Docker-Empire) — Docker Infrastructure
-- [OpenSIN-onboarding](https://github.com/OpenSIN-AI/OpenSIN-onboarding) — User Onboarding
+- [Infra-SIN-Dev-Setup / user-onboarding](https://github.com/OpenSIN-AI/Infra-SIN-Dev-Setup/tree/main/user-onboarding) — User Onboarding
 
 ---
 


### PR DESCRIPTION
## Summary

Point every active documentation page at the canonical post-consolidation location instead of the archived standalone repos.

### Files changed

| File | Change |
|---|---|
| `docs/guide/onboarding.md` | Clone URL and repo link -> `Infra-SIN-Dev-Setup/user-onboarding` |
| `docs/guide/opensin-ai-code.md` | **Full rewrite.** Page no longer claims a standalone repo exists; points at `OpenSIN/opensin_agent_platform/` and the rationalization plan |
| `docs/guide/opensin-ai-overview.md` | Comparison-table row updated |
| `docs/guide/opensin-code.md` | Comparison-table row updated |
| `docs/guide/passwordmanager.md` | `OpenSIN-onboarding` link -> `Infra-SIN-Dev-Setup/user-onboarding` |
| `docs/storage/box-cloud-storage.md` | Same |
| `docs/audit/agents-mandate-audit.md` | All archived-repo URLs -> canonical targets |

### Out of scope

- `.vitepress/dist/` build output: untouched (will be regenerated on next build)
- Archived repos' own READMEs: already carry redirect notices from wave 1/2

### Verification

After this PR, no active `.md` file under `docs/` links to an archived repo:

```bash
grep -rn 'OpenSIN-AI/opensin-ai-code\|OpenSIN-AI/OpenSIN-onboarding\|OpenSIN-AI/A2A-SIN-Coding-CEO\|OpenSIN-AI/A2A-SIN-Code-AI' docs/ --include='*.md' | grep -v dist/
# (no output)
```

Related: https://github.com/OpenSIN-AI/OpenSIN-overview/blob/main/docs/CONSOLIDATION-2026-04.md

Co-authored-by: v0[bot] <v0[bot]@users.noreply.github.com>