### PR TITLE
fix(ci): restore repo health build gate

### DIFF
--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -1,4 +1,4 @@
-name: Repo Health Check
+name: Repo Health Build Gate
 
 on:
   push:
@@ -74,7 +74,6 @@ jobs:
 
   bun-build-check:
     runs-on: ubuntu-latest
-    if: ${{ hashFiles('package.json') != '' }}
     
     steps:
       - name: Checkout repo


### PR DESCRIPTION
## Summary
- fix the dedicated `repo-health.yml` workflow so it evaluates and runs normally again
- remove the job-level condition that caused the workflow-file failure on branch and main pushes
- give the workflow a distinct name in Actions so it is easier to separate from `repo-health-check.yml`

## Validation
- `python3` + `yaml.safe_load` parses `.github/workflows/repo-health.yml`
- branch status is clean after the workflow-only change