### PR TITLE
fix(ci): deploy plain docs artifact to Cloudflare

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -171,10 +171,18 @@ jobs:
       # STEP 9: Upload build artifacts for deploy job
       # Artifacts are needed because build and deploy are separate jobs
       # -----------------------------------------------------------------------
+      - name: Verify guide routes exist in build output
+        if: github.ref == 'refs/heads/main'
+        run: |
+          test -f docs/.vitepress/dist/guide/getting-started.html
+          test -f docs/.vitepress/dist/guide/changelog.html
+          echo "PASS: Guide routes are present in the built output"
+
       - name: Upload build artifacts
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
+          name: docs-site-dist
           path: docs/.vitepress/dist
 
   # ---------------------------------------------------------------------------
@@ -201,7 +209,7 @@ jobs:
       - name: Download built artifacts
         uses: actions/download-artifact@v4
         with:
-          name: github-pages
+          name: docs-site-dist
           path: docs/.vitepress/dist
 
       # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- switch the Cloudflare deploy workflow from the GitHub Pages-specific artifact action to a plain artifact upload/download pair
- add an explicit build-time assertion that `guide/getting-started.html` and `guide/changelog.html` exist before upload
- address the live 404 problem where `/guide/*` routes were missing on `docs.opensin.ai` even though they existed in the local VitePress build output

## Validation
- `.github/workflows/docs.yml` parses successfully with `python3` + `yaml.safe_load`
- `bun ./scripts/build-docs.mjs` succeeds locally
- local build output contains both `docs/.vitepress/dist/guide/getting-started.html` and `docs/.vitepress/dist/guide/changelog.html`

## Issue
- closes #155